### PR TITLE
Allow setting log level for service

### DIFF
--- a/pysportbot/service/__main__.py
+++ b/pysportbot/service/__main__.py
@@ -15,7 +15,8 @@ def main() -> None:
     parser.add_argument(
         "--retry-delay-minutes", type=int, default=2, help="Delay in minutes between retries for weekly bookings."
     )
-    parser.add_argument("--time_zone", type=str, default="Europe/Madrid", help="Timezone for the service.")
+    parser.add_argument("--time-zone", type=str, default="Europe/Madrid", help="Timezone for the service.")
+    parser.add_argument("--log-level", type=str, default="INFO", help="Logging level for the service.")
     args = parser.parse_args()
 
     config: Dict[str, Any] = load_config(args.config)
@@ -25,6 +26,7 @@ def main() -> None:
         retry_attempts=args.retry_attempts,
         retry_delay_minutes=args.retry_delay_minutes,
         time_zone=args.time_zone,
+        log_level=args.log_level,
     )
 
 

--- a/pysportbot/service/service.py
+++ b/pysportbot/service/service.py
@@ -9,8 +9,6 @@ from pysportbot.utils.logger import get_logger
 from .booking import schedule_bookings
 from .config_validator import validate_activities, validate_config
 
-logger = get_logger(__name__)
-
 
 def run_service(
     config: Dict[str, Any],
@@ -18,12 +16,16 @@ def run_service(
     retry_attempts: int,
     retry_delay_minutes: int,
     time_zone: str = "Europe/Madrid",
+    log_level: str = "INFO",
 ) -> None:
+    # Initialize service logger
+    logger = get_logger(__name__)
+    logger.setLevel(log_level)
 
     # Validate the configuration file
     validate_config(config)
-
-    bot = SportBot()
+    # Initialize the SportBot instance
+    bot = SportBot(log_level=log_level)
     bot.login(config["email"], config["password"], config["centre"])
 
     # Validate the activities in the configuration file


### PR DESCRIPTION
Allows setting the log level when running the service

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added ability to specify logging level via command-line argument
	- Improved logging configuration for the service

- **Chores**
	- Updated command-line argument naming convention from `--time_zone` to `--time-zone`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->