### PR TITLE
Allow different time zones in logger

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,11 +19,11 @@ check: ## Run code quality tools.
 .PHONY: test
 test: ## Test all and generate code coverage report
 	@echo "🚀 Testing code: Running all tests with code coverage"
-	@poetry run pytest -s --cov --cov-config=pyproject.toml --cov-report=xml
+	@poetry run pytest --cov --cov-config=pyproject.toml --cov-report=xml
 
 test-%: ## Test a specific test case with pytest, e.g. make test-load_geometry
 	@echo "🚀 Testing code: Running the specified test case"
-	@poetry run pytest -s -k $*
+	@poetry run pytest -k $*
 
 .PHONY: build
 build: clean-build ## Build wheel file using poetry

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ pip install pysportbot
 from pysportbot import SportBot
 
 # Create bot instance, will list available centres if requested
-bot = SportBot(log_level='INFO', print_centres=False)
+bot = SportBot(log_level='INFO', print_centres=False, time_zone = 'Europe/Madrid')
 
 # Connect to service with email and password as well as the name of the centre
 bot.login('email', 'password', 'centre')
@@ -117,7 +117,7 @@ python -m pysportbot.service --help
 Currently supported options include
 1.  ```--retry-attempts``` sets the number of retries attempted in case a booking attempt fails
 2. ```--retry-delay-minutes``` sets the delay in minutes between retries for weekly bookings
-3. ```--time-zone``` sets the time zone for the service
+3. ```--time-zone``` sets the time zone for the service (e.g. Europe/Madrid)
 4. ```--log-level``` sets the log-level of the service (e.g. DEBUG, INFO, WARNING, ERROR)
 
 ## LICENSE

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ pip install pysportbot
 from pysportbot import SportBot
 
 # Create bot instance, will list available centres if requested
-bot = SportBot(log_level='INFO', print_centres=False)
+bot = SportBot(log_level='INFO', print_centres=False, time_zone = 'Europe/Madrid')
 
 # Connect to service with email and password as well as the name of the centre
 bot.login('email', 'password', 'centre')

--- a/pysportbot/__init__.py
+++ b/pysportbot/__init__.py
@@ -1,3 +1,5 @@
+# pysportbot/sportbot.py
+
 import logging
 from typing import Optional
 
@@ -15,10 +17,12 @@ from .utils.logger import set_log_level, setup_logger
 class SportBot:
     """Unified interface for interacting with the booking system."""
 
-    def __init__(self, log_level: str = "INFO", print_centres: bool = False) -> None:
+    def __init__(self, log_level: str = "INFO", print_centres: bool = False, time_zone: str = "Europe/Madrid") -> None:
         setup_logger(log_level)
         self._logger = logging.getLogger("SportBot")
         self._logger.info("Initializing SportBot...")
+        self._logger.info(f"Log level: {log_level}")
+        self._logger.info(f"Time zone: {time_zone}")
         self._centres = Centres(print_centres)
         self._session: Session = Session()
         self._auth: Optional[Authenticator] = None
@@ -32,7 +36,6 @@ class SportBot:
         self._logger.info(f"Log level changed to {log_level}.")
 
     def login(self, email: str, password: str, centre: str) -> None:
-
         # Check if the selected centre is valid
         self._centres.check_centre(centre)
         self._logger.info(f"Selected centre: {centre}")

--- a/pysportbot/service/service.py
+++ b/pysportbot/service/service.py
@@ -25,7 +25,7 @@ def run_service(
     # Validate the configuration file
     validate_config(config)
     # Initialize the SportBot instance
-    bot = SportBot(log_level=log_level)
+    bot = SportBot(log_level=log_level, time_zone=time_zone)
     bot.login(config["email"], config["password"], config["centre"])
 
     # Validate the activities in the configuration file

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,7 @@ def bot():
     assert centre is not None, "SPORTBOT_CENTRE is not set in the environment."
 
     # Create a new SportBot instance with DEBUG logging
-    bot = SportBot(log_level="DEBUG", print_centres=False)
+    bot = SportBot(log_level="DEBUG", print_centres=False, time_zone="Europe/Madrid")
 
     # Log in to user account
     bot.login(email, password, centre)

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,157 @@
+import logging
+import unittest
+from datetime import datetime
+from io import StringIO
+from unittest.mock import patch
+
+import pytz
+
+# Import the logger setup functions and classes
+from pysportbot.utils.logger import ColorFormatter, get_logger, set_log_level, setup_logger
+
+
+class TestLogger(unittest.TestCase):
+    def setUp(self):
+        """Set up a test logging configuration using the root logger."""
+        self.log_stream = StringIO()  # Capture logging output
+        self.initial_timezone = pytz.timezone("Europe/Madrid")
+
+        # Configure a test handler with ColorFormatter
+        self.handler = logging.StreamHandler(self.log_stream)
+        self.formatter = ColorFormatter(
+            "[%(asctime)s] [%(levelname)s] %(message)s", datefmt="%Y-%m-%d %H:%M:%S", tz=self.initial_timezone
+        )
+        self.handler.setFormatter(self.formatter)
+        self.handler.setLevel(logging.NOTSET)  # Let the logger handle the level
+
+        # Get the root logger and configure it
+        self.root_logger = logging.getLogger()
+        self.root_logger.setLevel(logging.INFO)
+        # Remove existing handlers to prevent duplicate logs
+        self.root_logger.handlers = []
+        self.root_logger.addHandler(self.handler)
+
+    def tearDown(self):
+        """Clean up by removing the handler."""
+        self.root_logger.removeHandler(self.handler)
+        self.log_stream.close()
+
+    def test_default_timezone(self):
+        """Test the logger defaults to Europe/Madrid time zone."""
+        setup_logger(level="INFO", timezone="Europe/Madrid")
+        self.root_logger.info("Test default time zone.")
+
+        self.handler.flush()
+        log_output = self.log_stream.getvalue().strip()
+        timestamp_str = log_output.split("]")[0].strip("[]")
+        log_time = datetime.strptime(timestamp_str, "%Y-%m-%d %H:%M:%S")
+
+        # Convert log time to Europe/Madrid time zone
+        log_time_with_tz = self.initial_timezone.localize(log_time)
+        now_madrid = datetime.now(self.initial_timezone)
+
+        # Assert timestamps are almost equal
+        self.assertAlmostEqual(log_time_with_tz.timestamp(), now_madrid.timestamp(), delta=2)
+
+    def test_log_levels(self):
+        """Test logs are filtered correctly by level."""
+        setup_logger(level="WARNING", timezone="Europe/Madrid")
+        self.root_logger.debug("This should not appear.")
+        self.root_logger.info("This should not appear.")
+        self.root_logger.warning("This is a warning.")
+        self.root_logger.error("This is an error.")
+
+        self.handler.flush()
+        log_output = self.log_stream.getvalue().strip()
+
+        # Assert only WARNING and ERROR levels are logged
+        self.assertIn("This is a warning.", log_output)
+        self.assertIn("This is an error.", log_output)
+        self.assertNotIn("This should not appear.", log_output)
+
+    def test_color_formatting(self):
+        """Test log levels include correct color codes."""
+        setup_logger(level="INFO", timezone="Europe/Madrid")
+        self.root_logger.info("Info message")
+        self.root_logger.warning("Warning message")
+        self.root_logger.error("Error message")
+
+        self.handler.flush()
+        log_output = self.log_stream.getvalue()
+
+        # Assert color codes are applied
+        self.assertIn("\033[92mINFO\033[0m", log_output)  # Green for INFO
+        self.assertIn("\033[93mWARNING\033[0m", log_output)  # Yellow for WARNING
+        self.assertIn("\033[91mERROR\033[0m", log_output)  # Red for ERROR
+
+    def test_invalid_log_level(self):
+        """Test that invalid log levels raise a ValueError."""
+        with self.assertRaises(ValueError):
+            set_log_level("INVALID_LEVEL")
+
+    def test_no_duplicate_handlers(self):
+        """Test multiple calls to setup_logger do not add duplicate handlers."""
+        setup_logger(level="INFO", timezone="Europe/Madrid")
+        setup_logger(level="INFO", timezone="Europe/Madrid")  # Call again
+
+        self.root_logger.info("Test for duplicate handlers.")
+
+        self.handler.flush()
+        log_output = self.log_stream.getvalue()
+
+        # Assert message appears only once
+        self.assertEqual(log_output.count("Test for duplicate handlers."), 1)
+
+    @patch("pysportbot.utils.logger.datetime")
+    def test_custom_timezone(self, mock_datetime):
+        """Test the logger outputs timestamps in a custom time zone."""
+        # Define a fixed current time
+        fixed_time_naive = datetime(2024, 12, 31, 14, 12, 23)
+        timezone_ny = pytz.timezone("America/New_York")
+        fixed_time = timezone_ny.localize(fixed_time_naive)
+
+        # Mock datetime.now() to return the fixed_time
+        mock_datetime.now.return_value = fixed_time
+        # Mock datetime.fromtimestamp() to return the fixed_time
+        mock_datetime.fromtimestamp.return_value = fixed_time
+        # Allow datetime.strptime() to work normally
+        mock_datetime.strptime.side_effect = datetime.strptime
+
+        # Set up logger with America/New_York timezone
+        setup_logger(level="INFO", timezone="America/New_York")
+        # Update the formatter's timezone
+        self.formatter.tz = timezone_ny
+        self.root_logger.info("Test custom time zone.")
+
+        self.handler.flush()
+        log_output = self.log_stream.getvalue().strip()
+        timestamp_str = log_output.split("]")[0].strip("[]")
+        log_time = datetime.strptime(timestamp_str, "%Y-%m-%d %H:%M:%S")
+
+        # Assign timezone to log_time
+        log_time_with_tz = timezone_ny.localize(log_time)
+        now_ny = fixed_time
+
+        # Calculate the absolute difference in seconds
+        time_difference = abs((now_ny - log_time_with_tz).total_seconds())
+
+        # Assert that the log_time matches the fixed_time exactly
+        self.assertEqual(time_difference, 0, f"Time difference is not zero: {time_difference} seconds")
+
+    def test_named_logger(self):
+        """Test that a named logger is correctly retrieved."""
+        setup_logger(level="INFO", timezone="Europe/Madrid")
+        logger = get_logger("test_named_logger")
+        logger.setLevel(logging.INFO)
+        logger.addHandler(self.handler)
+        logger.info("Test named logger.")
+
+        self.handler.flush()
+        log_output = self.log_stream.getvalue()
+
+        # Assert logger name appears in the output with colorized level
+        self.assertIn("[\033[92mINFO\033[0m] Test named logger.", log_output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Allows setting different time zones for logging times

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added time zone configuration support for SportBot, defaulting to 'Europe/Madrid'
  - Enhanced logging with timezone-aware timestamp formatting

- **Improvements**
  - Updated documentation to reflect new time zone configuration option
  - Refined logging functionality to provide more contextual information

- **Testing**
  - Added comprehensive test suite for logging functionality
  - Improved test coverage for logger configuration and behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->