### PR TITLE
Add MT support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ You can easily run `pysportbot` as a service to manage your bookings automatical
 ```bash
 python -m pysportbot.service --config config.json
 ```
-The service requires a `json` configuration file that specifies your user data and how you would like to book your classes. Currently, three types of configuration are supported:
+The service requires a `json` configuration file that specifies your user data and how you would like to book your classes. Currently, two types of configuration are supported:
 
 ##### 1. Book an upcoming class now
 
@@ -59,13 +59,13 @@ Let's say you would like to book Yoga next Monday at 18:00:00, then your `config
     "email": "your-email",
     "password": "your-password",
     "center": "your-gym-name",
+    "booking_execution": "now",
+
     "classes": [
         {
             "activity": "Yoga",
             "class_day": "Monday",
             "class_time": "18:00:00",
-            "booking_execution": "now",
-            "weekly": false
         }
     ]
 }
@@ -79,32 +79,13 @@ Let's say you would like to book Yoga next Monday at 18:00:00, but the execution
     "email": "your-email",
     "password": "your-password",
     "center": "your-gym-name",
-    "classes": [
-        {
-            "activity": "Yoga",
-            "class_day": "Monday",
-            "class_time": "18:00:00",
-            "booking_execution": "Friday 07:30:00",
-            "weekly": false
-        }
-    ]
-}
-```
-##### 3. Schedule weekly booking at specific execution day and time
-Let's say you would like to book Yoga every Monday at 18:00:00 and the booking execution should be every Friday at 07:30:00 then your `config.json` would look like:
+    "booking_execution": "Friday 07:30:00",
 
-```json
-{
-    "email": "your-email",
-    "password": "your-password",
-    "center": "your-gym-name",
     "classes": [
         {
             "activity": "Yoga",
             "class_day": "Monday",
             "class_time": "18:00:00",
-            "booking_execution": "Friday 07:30:00",
-            "weekly": true
         }
     ]
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,13 +59,13 @@ Let's say you would like to book Yoga next Monday at 18:00:00, then your `config
     "email": "your-email",
     "password": "your-password",
     "center": "your-gym-name",
+    "booking_execution": "now",
+
     "classes": [
         {
             "activity": "Yoga",
             "class_day": "Monday",
             "class_time": "18:00:00",
-            "booking_execution": "now",
-            "weekly": false
         }
     ]
 }
@@ -79,32 +79,13 @@ Let's say you would like to book Yoga next Monday at 18:00:00, but the execution
     "email": "your-email",
     "password": "your-password",
     "center": "your-gym-name",
-    "classes": [
-        {
-            "activity": "Yoga",
-            "class_day": "Monday",
-            "class_time": "18:00:00",
-            "booking_execution": "Friday 07:30:00",
-            "weekly": false
-        }
-    ]
-}
-```
-##### 3. Schedule weekly booking at specific execution day and time
-Let's say you would like to book Yoga every Monday at 18:00:00 and the booking execution should be every Friday at 07:30:00 then your `config.json` would look like:
+    "booking_execution": "Friday 07:30:00",
 
-```json
-{
-    "email": "your-email",
-    "password": "your-password",
-    "center": "your-gym-name",
     "classes": [
         {
             "activity": "Yoga",
             "class_day": "Monday",
             "class_time": "18:00:00",
-            "booking_execution": "Friday 07:30:00",
-            "weekly": true
         }
     ]
 }

--- a/poetry.lock
+++ b/poetry.lock
@@ -570,13 +570,13 @@ colorama = ">=0.4"
 
 [[package]]
 name = "identify"
-version = "2.6.3"
+version = "2.6.4"
 description = "File identification library for Python"
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "identify-2.6.3-py2.py3-none-any.whl", hash = "sha256:9edba65473324c2ea9684b1f944fe3191db3345e50b6d04571d10ed164f8d7bd"},
-    {file = "identify-2.6.3.tar.gz", hash = "sha256:62f5dae9b5fef52c84cc188514e9ea4f3f636b1d8799ab5ebc475471f9e47a02"},
+    {file = "identify-2.6.4-py2.py3-none-any.whl", hash = "sha256:993b0f01b97e0568c179bb9196391ff391bfb88a99099dbf5ce392b68f42d0af"},
+    {file = "identify-2.6.4.tar.gz", hash = "sha256:285a7d27e397652e8cafe537a6cc97dd470a970f48fb2e9d979aa38eae5513ac"},
 ]
 
 [package.extras]
@@ -1043,43 +1043,49 @@ mkdocstrings = ">=0.26"
 
 [[package]]
 name = "mypy"
-version = "1.14.0"
+version = "1.14.1"
 description = "Optional static typing for Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "mypy-1.14.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e971c1c667007f9f2b397ffa80fa8e1e0adccff336e5e77e74cb5f22868bee87"},
-    {file = "mypy-1.14.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e86aaeaa3221a278c66d3d673b297232947d873773d61ca3ee0e28b2ff027179"},
-    {file = "mypy-1.14.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1628c5c3ce823d296e41e2984ff88c5861499041cb416a8809615d0c1f41740e"},
-    {file = "mypy-1.14.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:7fadb29b77fc14a0dd81304ed73c828c3e5cde0016c7e668a86a3e0dfc9f3af3"},
-    {file = "mypy-1.14.0-cp310-cp310-win_amd64.whl", hash = "sha256:3fa76988dc760da377c1e5069200a50d9eaaccf34f4ea18428a3337034ab5a44"},
-    {file = "mypy-1.14.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6e73c8a154eed31db3445fe28f63ad2d97b674b911c00191416cf7f6459fd49a"},
-    {file = "mypy-1.14.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:273e70fcb2e38c5405a188425aa60b984ffdcef65d6c746ea5813024b68c73dc"},
-    {file = "mypy-1.14.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1daca283d732943731a6a9f20fdbcaa927f160bc51602b1d4ef880a6fb252015"},
-    {file = "mypy-1.14.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:7e68047bedb04c1c25bba9901ea46ff60d5eaac2d71b1f2161f33107e2b368eb"},
-    {file = "mypy-1.14.0-cp311-cp311-win_amd64.whl", hash = "sha256:7a52f26b9c9b1664a60d87675f3bae00b5c7f2806e0c2800545a32c325920bcc"},
-    {file = "mypy-1.14.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d5326ab70a6db8e856d59ad4cb72741124950cbbf32e7b70e30166ba7bbf61dd"},
-    {file = "mypy-1.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:bf4ec4980bec1e0e24e5075f449d014011527ae0055884c7e3abc6a99cd2c7f1"},
-    {file = "mypy-1.14.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:390dfb898239c25289495500f12fa73aa7f24a4c6d90ccdc165762462b998d63"},
-    {file = "mypy-1.14.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7e026d55ddcd76e29e87865c08cbe2d0104e2b3153a523c529de584759379d3d"},
-    {file = "mypy-1.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:585ed36031d0b3ee362e5107ef449a8b5dfd4e9c90ccbe36414ee405ee6b32ba"},
-    {file = "mypy-1.14.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e9f6f4c0b27401d14c483c622bc5105eff3911634d576bbdf6695b9a7c1ba741"},
-    {file = "mypy-1.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:56b2280cedcb312c7a79f5001ae5325582d0d339bce684e4a529069d0e7ca1e7"},
-    {file = "mypy-1.14.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:342de51c48bab326bfc77ce056ba08c076d82ce4f5a86621f972ed39970f94d8"},
-    {file = "mypy-1.14.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:00df23b42e533e02a6f0055e54de9a6ed491cd8b7ea738647364fd3a39ea7efc"},
-    {file = "mypy-1.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:e8c8387e5d9dff80e7daf961df357c80e694e942d9755f3ad77d69b0957b8e3f"},
-    {file = "mypy-1.14.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0b16738b1d80ec4334654e89e798eb705ac0c36c8a5c4798496cd3623aa02286"},
-    {file = "mypy-1.14.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:10065fcebb7c66df04b05fc799a854b1ae24d9963c8bb27e9064a9bdb43aa8ad"},
-    {file = "mypy-1.14.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fbb7d683fa6bdecaa106e8368aa973ecc0ddb79a9eaeb4b821591ecd07e9e03c"},
-    {file = "mypy-1.14.0-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:3498cb55448dc5533e438cd13d6ddd28654559c8c4d1fd4b5ca57a31b81bac01"},
-    {file = "mypy-1.14.0-cp38-cp38-win_amd64.whl", hash = "sha256:c7b243408ea43755f3a21a0a08e5c5ae30eddb4c58a80f415ca6b118816e60aa"},
-    {file = "mypy-1.14.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:14117b9da3305b39860d0aa34b8f1ff74d209a368829a584eb77524389a9c13e"},
-    {file = "mypy-1.14.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:af98c5a958f9c37404bd4eef2f920b94874507e146ed6ee559f185b8809c44cc"},
-    {file = "mypy-1.14.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f0b343a1d3989547024377c2ba0dca9c74a2428ad6ed24283c213af8dbb0710b"},
-    {file = "mypy-1.14.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:cdb5563c1726c85fb201be383168f8c866032db95e1095600806625b3a648cb7"},
-    {file = "mypy-1.14.0-cp39-cp39-win_amd64.whl", hash = "sha256:74e925649c1ee0a79aa7448baf2668d81cc287dc5782cff6a04ee93f40fb8d3f"},
-    {file = "mypy-1.14.0-py3-none-any.whl", hash = "sha256:2238d7f93fc4027ed1efc944507683df3ba406445a2b6c96e79666a045aadfab"},
-    {file = "mypy-1.14.0.tar.gz", hash = "sha256:822dbd184d4a9804df5a7d5335a68cf7662930e70b8c1bc976645d1509f9a9d6"},
+    {file = "mypy-1.14.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:52686e37cf13d559f668aa398dd7ddf1f92c5d613e4f8cb262be2fb4fedb0fcb"},
+    {file = "mypy-1.14.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1fb545ca340537d4b45d3eecdb3def05e913299ca72c290326be19b3804b39c0"},
+    {file = "mypy-1.14.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:90716d8b2d1f4cd503309788e51366f07c56635a3309b0f6a32547eaaa36a64d"},
+    {file = "mypy-1.14.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2ae753f5c9fef278bcf12e1a564351764f2a6da579d4a81347e1d5a15819997b"},
+    {file = "mypy-1.14.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e0fe0f5feaafcb04505bcf439e991c6d8f1bf8b15f12b05feeed96e9e7bf1427"},
+    {file = "mypy-1.14.1-cp310-cp310-win_amd64.whl", hash = "sha256:7d54bd85b925e501c555a3227f3ec0cfc54ee8b6930bd6141ec872d1c572f81f"},
+    {file = "mypy-1.14.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f995e511de847791c3b11ed90084a7a0aafdc074ab88c5a9711622fe4751138c"},
+    {file = "mypy-1.14.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d64169ec3b8461311f8ce2fd2eb5d33e2d0f2c7b49116259c51d0d96edee48d1"},
+    {file = "mypy-1.14.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ba24549de7b89b6381b91fbc068d798192b1b5201987070319889e93038967a8"},
+    {file = "mypy-1.14.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:183cf0a45457d28ff9d758730cd0210419ac27d4d3f285beda038c9083363b1f"},
+    {file = "mypy-1.14.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f2a0ecc86378f45347f586e4163d1769dd81c5a223d577fe351f26b179e148b1"},
+    {file = "mypy-1.14.1-cp311-cp311-win_amd64.whl", hash = "sha256:ad3301ebebec9e8ee7135d8e3109ca76c23752bac1e717bc84cd3836b4bf3eae"},
+    {file = "mypy-1.14.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:30ff5ef8519bbc2e18b3b54521ec319513a26f1bba19a7582e7b1f58a6e69f14"},
+    {file = "mypy-1.14.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:cb9f255c18052343c70234907e2e532bc7e55a62565d64536dbc7706a20b78b9"},
+    {file = "mypy-1.14.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b4e3413e0bddea671012b063e27591b953d653209e7a4fa5e48759cda77ca11"},
+    {file = "mypy-1.14.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:553c293b1fbdebb6c3c4030589dab9fafb6dfa768995a453d8a5d3b23784af2e"},
+    {file = "mypy-1.14.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fad79bfe3b65fe6a1efaed97b445c3d37f7be9fdc348bdb2d7cac75579607c89"},
+    {file = "mypy-1.14.1-cp312-cp312-win_amd64.whl", hash = "sha256:8fa2220e54d2946e94ab6dbb3ba0a992795bd68b16dc852db33028df2b00191b"},
+    {file = "mypy-1.14.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:92c3ed5afb06c3a8e188cb5da4984cab9ec9a77ba956ee419c68a388b4595255"},
+    {file = "mypy-1.14.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:dbec574648b3e25f43d23577309b16534431db4ddc09fda50841f1e34e64ed34"},
+    {file = "mypy-1.14.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8c6d94b16d62eb3e947281aa7347d78236688e21081f11de976376cf010eb31a"},
+    {file = "mypy-1.14.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d4b19b03fdf54f3c5b2fa474c56b4c13c9dbfb9a2db4370ede7ec11a2c5927d9"},
+    {file = "mypy-1.14.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0c911fde686394753fff899c409fd4e16e9b294c24bfd5e1ea4675deae1ac6fd"},
+    {file = "mypy-1.14.1-cp313-cp313-win_amd64.whl", hash = "sha256:8b21525cb51671219f5307be85f7e646a153e5acc656e5cebf64bfa076c50107"},
+    {file = "mypy-1.14.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:7084fb8f1128c76cd9cf68fe5971b37072598e7c31b2f9f95586b65c741a9d31"},
+    {file = "mypy-1.14.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:8f845a00b4f420f693f870eaee5f3e2692fa84cc8514496114649cfa8fd5e2c6"},
+    {file = "mypy-1.14.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:44bf464499f0e3a2d14d58b54674dee25c031703b2ffc35064bd0df2e0fac319"},
+    {file = "mypy-1.14.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c99f27732c0b7dc847adb21c9d47ce57eb48fa33a17bc6d7d5c5e9f9e7ae5bac"},
+    {file = "mypy-1.14.1-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:bce23c7377b43602baa0bd22ea3265c49b9ff0b76eb315d6c34721af4cdf1d9b"},
+    {file = "mypy-1.14.1-cp38-cp38-win_amd64.whl", hash = "sha256:8edc07eeade7ebc771ff9cf6b211b9a7d93687ff892150cb5692e4f4272b0837"},
+    {file = "mypy-1.14.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3888a1816d69f7ab92092f785a462944b3ca16d7c470d564165fe703b0970c35"},
+    {file = "mypy-1.14.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:46c756a444117c43ee984bd055db99e498bc613a70bbbc120272bd13ca579fbc"},
+    {file = "mypy-1.14.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:27fc248022907e72abfd8e22ab1f10e903915ff69961174784a3900a8cba9ad9"},
+    {file = "mypy-1.14.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:499d6a72fb7e5de92218db961f1a66d5f11783f9ae549d214617edab5d4dbdbb"},
+    {file = "mypy-1.14.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:57961db9795eb566dc1d1b4e9139ebc4c6b0cb6e7254ecde69d1552bf7613f60"},
+    {file = "mypy-1.14.1-cp39-cp39-win_amd64.whl", hash = "sha256:07ba89fdcc9451f2ebb02853deb6aaaa3d2239a236669a63ab3801bbf923ef5c"},
+    {file = "mypy-1.14.1-py3-none-any.whl", hash = "sha256:b66a60cc4073aeb8ae00057f9c1f64d49e90f918fbcef9a977eb121da8b8f1d1"},
+    {file = "mypy-1.14.1.tar.gz", hash = "sha256:7ec88144fe9b510e8475ec2f5f251992690fcf89ccb4500b214b4226abcd32d6"},
 ]
 
 [package.dependencies]
@@ -2006,20 +2012,6 @@ packaging = ">=23.2"
 types-setuptools = ">=69.1.0"
 
 [[package]]
-name = "schedule"
-version = "1.2.2"
-description = "Job scheduling for humans."
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "schedule-1.2.2-py3-none-any.whl", hash = "sha256:5bef4a2a0183abf44046ae0d164cadcac21b1db011bdd8102e4a0c1e91e06a7d"},
-    {file = "schedule-1.2.2.tar.gz", hash = "sha256:15fe9c75fe5fd9b9627f3f19cc0ef1420508f9f9a46f45cd0769ef75ede5f0b7"},
-]
-
-[package.extras]
-timezone = ["pytz"]
-
-[[package]]
 name = "six"
 version = "1.17.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -2333,4 +2325,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.13"
-content-hash = "dfccedd8663b6221b7510f2e36b3bfcda0dd4e365d841d108f00dc1af2e8db0e"
+content-hash = "6b0b983c86a09dcd3786f62814798a244618ff08f3c9304da43558fb89cd4ceb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ requests = "^2.32.3"
 beautifulsoup4 = "^4.12.3"
 pandas = "^2.2.3"
 pytz = "^2024.2"
-schedule = "^1.2.2"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.4"

--- a/pysportbot/activities.py
+++ b/pysportbot/activities.py
@@ -92,7 +92,7 @@ class Activities:
             logger.warning(warning_msg)
             return DataFrame()
 
-        logger.info(f"Daily slots fetched for '{activity_name}' on {day}.")
+        logger.debug(f"Daily slots fetched for '{activity_name}' on {day}.")
 
         # Filter desired columns
         columns = [

--- a/pysportbot/service/booking.py
+++ b/pysportbot/service/booking.py
@@ -1,147 +1,156 @@
 import time
-from datetime import datetime, timedelta
-from typing import Any, Dict
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime
+from typing import Any, Dict, List
 
 import pytz
-import schedule
 
 from pysportbot import SportBot
 from pysportbot.utils.errors import ErrorMessages
 from pysportbot.utils.logger import get_logger
 
-from .config_validator import DAY_MAP
 from .scheduling import calculate_class_day, calculate_next_execution
 
 logger = get_logger(__name__)
 
 
 def _raise_no_matching_slots_error(activity: str, class_time: str, booking_date: str) -> None:
-    """
-    Helper function to raise a ValueError for no matching slots.
-    """
     raise ValueError(ErrorMessages.no_matching_slots_for_time(activity, class_time, booking_date))
+
+
+def wait_for_execution(booking_execution: str, time_zone: str) -> None:
+    """
+    Wait until the specified global execution time.
+
+    Args:
+        booking_execution (str): Global execution time in "Day HH:MM:SS" format.
+        time_zone (str): Timezone for calculation.
+    """
+    tz = pytz.timezone(time_zone)
+    execution_time = calculate_next_execution(booking_execution, time_zone)
+    now = datetime.now(tz)
+    time_until_execution = (execution_time - now).total_seconds()
+
+    if time_until_execution > 0:
+        logger.info(
+            f"Waiting {time_until_execution:.2f} seconds until global execution time: "
+            f"{execution_time.strftime('%Y-%m-%d %H:%M:%S %z')}."
+        )
+        time.sleep(time_until_execution)
 
 
 def attempt_booking(
     bot: SportBot,
-    cls: Dict[str, Any],
+    activity: str,
+    class_day: str,
+    class_time: str,
     offset_seconds: int,
     retry_attempts: int = 1,
     retry_delay_minutes: int = 0,
     time_zone: str = "Europe/Madrid",
 ) -> None:
-    activity = cls["activity"]
-    class_day = cls["class_day"]
-    class_time = cls["class_time"]
-    booking_execution = cls["booking_execution"]
+    """
+    Attempt to book a slot for the given class.
 
+    Args:
+        bot (SportBot): The SportBot instance.
+        activity (str): Activity name.
+        class_day (str): Day of the class.
+        class_time (str): Time of the class.
+        offset_seconds (int): Delay before attempting booking.
+        retry_attempts (int): Number of retry attempts.
+        retry_delay_minutes (int): Delay between retries.
+        time_zone (str): Time zone for execution.
+    """
     for attempt_num in range(1, retry_attempts + 1):
         booking_date = calculate_class_day(class_day, time_zone).strftime("%Y-%m-%d")
 
         try:
-            logger.info(f"Fetching available slots for {activity} on {booking_date}")
+            logger.info(f"Fetching available slots for '{activity}' on {booking_date}.")
             available_slots = bot.daily_slots(activity=activity, day=booking_date)
 
             matching_slots = available_slots[available_slots["start_timestamp"] == f"{booking_date} {class_time}"]
             if matching_slots.empty:
                 _raise_no_matching_slots_error(activity, class_time, booking_date)
 
-            if booking_execution != "now":
-                logger.info(f"Waiting {offset_seconds} seconds before attempting booking.")
-                time.sleep(offset_seconds)
+            logger.info(f"Waiting {offset_seconds} seconds before attempting booking.")
+            time.sleep(offset_seconds)
 
             slot_id = matching_slots.iloc[0]["start_timestamp"]
-            logger.info(f"Attempting to book slot for {activity} at {slot_id} (Attempt {attempt_num}/{retry_attempts})")
+            logger.info(f"Attempting to book '{activity}' at {slot_id} (Attempt {attempt_num}/{retry_attempts}).")
             bot.book(activity=activity, start_time=slot_id)
-            logger.info(f"Successfully booked {activity} at {slot_id}")
 
         except Exception as e:
             error_str = str(e)
-            logger.warning(f"Attempt {attempt_num} failed for {activity}: {error_str}")
+            logger.warning(f"Attempt {attempt_num} failed: {error_str}")
 
             if ErrorMessages.slot_already_booked() in error_str:
-                logger.warning(f"{activity} at {class_time} on {booking_date} is already booked; skipping retry.")
+                logger.warning("Slot already booked; skipping further retries.")
                 return
 
             if attempt_num < retry_attempts:
                 logger.info(f"Retrying in {retry_delay_minutes} minutes...")
                 time.sleep(retry_delay_minutes * 60)
         else:
+            # If the booking attempt succeeds, log and exit
+            logger.info(f"Successfully booked '{activity}' at {slot_id}.")
             return
 
-    logger.error(f"Failed to book {activity} after {retry_attempts} attempts.")
+    # If all attempts fail, log an error
+    logger.error(f"Failed to book '{activity}' after {retry_attempts} attempts.")
 
 
-def schedule_bookings(
+def schedule_bookings_parallel(
     bot: SportBot,
-    config: Dict[str, Any],
-    cls: Dict[str, Any],
+    classes: List[Dict[str, Any]],
+    booking_execution: str,
     offset_seconds: int,
     retry_attempts: int,
     retry_delay_minutes: int,
-    time_zone: str = "Europe/Madrid",
+    time_zone: str,
+    max_threads: int,
 ) -> None:
-    booking_execution = cls["booking_execution"]
-    weekly = cls["weekly"]
-    activity = cls["activity"]
-    class_day = cls["class_day"]
-    class_time = cls["class_time"]
+    """
+    Execute bookings in parallel with a limit on the number of threads.
 
-    if weekly:
-        # For weekly bookings, schedule recurring jobs
-        execution_day, execution_time = booking_execution.split()
-        logger.info(
-            f"Class '{activity}' on {class_day} at {class_time} "
-            f"will be booked every {execution_day} at {execution_time}."
-        )
+    Args:
+        bot (SportBot): The SportBot instance.
+        classes (list): List of class configurations.
+        booking_execution (str): Global execution time for all bookings.
+        offset_seconds (int): Delay before each booking attempt.
+        retry_attempts (int): Number of retry attempts.
+        retry_delay_minutes (int): Delay between retries.
+        time_zone (str): Timezone for booking.
+        max_threads (int): Maximum number of threads to use.
+    """
+    # Log planned bookings
+    for cls in classes:
+        logger.info(f"Scheduled to book '{cls['activity']}' next {cls['class_day']} at {cls['class_time']}.")
 
-        def booking_task() -> None:
+    # Wait globally before starting bookings
+    wait_for_execution(booking_execution, time_zone)
+
+    with ThreadPoolExecutor(max_workers=max_threads) as executor:
+        future_to_class = {
+            executor.submit(
+                attempt_booking,
+                bot,
+                cls["activity"],
+                cls["class_day"],
+                cls["class_time"],
+                offset_seconds,
+                retry_attempts,
+                retry_delay_minutes,
+                time_zone,
+            ): cls
+            for cls in classes
+        }
+
+        for future in as_completed(future_to_class):
+            cls = future_to_class[future]
+            activity, class_time = cls["activity"], cls["class_time"]
             try:
-                logger.info("Re-authenticating before weekly booking...")
-                bot.login(config["email"], config["password"], config["centre"])
-                logger.info("Re-authentication successful.")
-                attempt_booking(
-                    bot,
-                    cls,
-                    offset_seconds,
-                    retry_attempts,
-                    retry_delay_minutes,
-                    time_zone,
-                )
+                future.result()
+                logger.info(f"Booking for '{activity}' at {class_time} completed successfully.")
             except Exception:
-                logger.exception(f"Failed to execute weekly booking task for {activity}")
-
-        # e.g., schedule.every().monday.at("HH:MM:SS").do(...)
-        getattr(schedule.every(), execution_day.lower()).at(execution_time).do(booking_task)
-
-    else:
-        # For one-off (non-weekly) bookings, calculate exact date/time
-        next_execution = calculate_next_execution(booking_execution, time_zone)
-        tz = pytz.timezone(time_zone)
-
-        day_of_week_target = DAY_MAP[class_day.lower().strip()]
-        execution_day_of_week = next_execution.weekday()
-
-        days_to_class = (day_of_week_target - execution_day_of_week + 7) % 7
-        planned_class_date_dt = next_execution + timedelta(days=days_to_class)
-        planned_class_date_str = planned_class_date_dt.strftime("%Y-%m-%d (%A)")
-
-        next_execution_str = next_execution.strftime("%Y-%m-%d (%A) %H:%M:%S %z")
-
-        logger.info(
-            f"Class '{activity}' on {planned_class_date_str} at {class_time} "
-            f"will be booked on {next_execution_str}."
-        )
-
-        # Wait until the next execution time
-        time_until_execution = (next_execution - datetime.now(tz)).total_seconds()
-        time.sleep(max(0, time_until_execution))
-
-        attempt_booking(
-            bot,
-            cls,
-            offset_seconds,
-            retry_attempts=retry_attempts,
-            retry_delay_minutes=retry_delay_minutes,
-            time_zone=time_zone,
-        )
+                logger.exception(f"Booking for '{activity}' at {class_time} failed.")

--- a/pysportbot/service/config_validator.py
+++ b/pysportbot/service/config_validator.py
@@ -11,36 +11,54 @@ DAY_MAP = {"monday": 0, "tuesday": 1, "wednesday": 2, "thursday": 3, "friday": 4
 
 
 def validate_config(config: Dict[str, Any]) -> None:
-    required_keys = ["email", "password", "centre", "classes"]
+    """
+    Validate the overall configuration structure and values.
+
+    Args:
+        config (Dict[str, Any]): Configuration dictionary.
+
+    Raises:
+        ValueError: If the configuration is invalid.
+    """
+
+    def raise_invalid_booking_format_error() -> None:
+        """Helper function to raise an error for invalid booking_execution format."""
+        raise ValueError(ErrorMessages.invalid_booking_execution_format())
+
+    required_keys = ["email", "password", "centre", "classes", "booking_execution"]
     for key in required_keys:
         if key not in config:
             raise ValueError(ErrorMessages.missing_required_key(key))
 
-    for cls in config["classes"]:
-        if (
-            "activity" not in cls
-            or "class_day" not in cls
-            or "class_time" not in cls
-            or "booking_execution" not in cls
-            or "weekly" not in cls
-        ):
-            raise ValueError(ErrorMessages.invalid_class_definition())
-
-        if cls["weekly"] and cls["booking_execution"] == "now":
-            raise ValueError(ErrorMessages.invalid_weekly_now())
-
-        if cls["booking_execution"] != "now":
-            day_and_time = cls["booking_execution"].split()
+    # Validate global booking_execution
+    if config["booking_execution"] != "now":
+        try:
+            day_and_time = config["booking_execution"].split()
             if len(day_and_time) != 2:
-                raise ValueError(ErrorMessages.invalid_booking_execution_format())
+                raise_invalid_booking_format_error()
+
             _, exec_time = day_and_time
-            try:
-                datetime.strptime(exec_time, "%H:%M:%S")
-            except ValueError as err:
-                raise ValueError(ErrorMessages.invalid_booking_execution_format()) from err
+            datetime.strptime(exec_time, "%H:%M:%S")
+        except ValueError:
+            raise_invalid_booking_format_error()
+
+    # Validate individual class definitions
+    for cls in config["classes"]:
+        if "activity" not in cls or "class_day" not in cls or "class_time" not in cls:
+            raise ValueError(ErrorMessages.invalid_class_definition())
 
 
 def validate_activities(bot: SportBot, config: Dict[str, Any]) -> None:
+    """
+    Validate that all activities specified in the configuration exist.
+
+    Args:
+        bot (SportBot): The SportBot instance.
+        config (Dict[str, Any]): Configuration dictionary.
+
+    Raises:
+        ValueError: If an activity is not found.
+    """
     logger.info("Fetching available activities for validation...")
     available_activities = bot.activities()
     available_activity_names = set(available_activities["name_activity"].tolist())
@@ -51,4 +69,5 @@ def validate_activities(bot: SportBot, config: Dict[str, Any]) -> None:
         activity_name = cls["activity"]
         if activity_name not in available_activity_names:
             raise ValueError(ErrorMessages.activity_not_found(activity_name, list(available_activity_names)))
+
     logger.info("All activities in the configuration file have been validated.")

--- a/pysportbot/service/service.py
+++ b/pysportbot/service/service.py
@@ -1,13 +1,10 @@
-import time
+import os
 from typing import Any, Dict
 
-import schedule
-
 from pysportbot import SportBot
+from pysportbot.service.booking import schedule_bookings_parallel
+from pysportbot.service.config_validator import validate_activities, validate_config
 from pysportbot.utils.logger import get_logger
-
-from .booking import schedule_bookings
-from .config_validator import validate_activities, validate_config
 
 
 def run_service(
@@ -18,32 +15,45 @@ def run_service(
     time_zone: str = "Europe/Madrid",
     log_level: str = "INFO",
 ) -> None:
-    # Initialize service logger
+    """
+    Run the booking service with the given configuration.
+
+    Args:
+        config (dict): Configuration dictionary for booking service.
+        offset_seconds (int): Delay before each booking attempt.
+        retry_attempts (int): Number of retry attempts.
+        retry_delay_minutes (int): Delay between retry attempts in minutes.
+        time_zone (str): Time zone for the booking.
+        log_level (str): Logging level for the service.
+    """
+    # Initialize logger
     logger = get_logger(__name__)
     logger.setLevel(log_level)
 
-    # Validate the configuration file
+    # Validate configuration
     validate_config(config)
-    # Initialize the SportBot instance
+
+    # Initialize the SportBot and authenticate
     bot = SportBot(log_level=log_level, time_zone=time_zone)
     bot.login(config["email"], config["password"], config["centre"])
 
-    # Validate the activities in the configuration file
+    # Validate activities in the configuration
     validate_activities(bot, config)
 
-    for cls in config["classes"]:
-        schedule_bookings(
-            bot,
-            config,
-            cls,
-            offset_seconds,
-            retry_attempts,
-            retry_delay_minutes,
-            time_zone,
-        )
+    # Determine the number of threads
+    max_threads = min(len(config["classes"]), os.cpu_count() or 1)
+    logger.info(f"Using up to {max_threads} threads for booking {len(config['classes'])} activities.")
 
-    if schedule.jobs:
-        logger.info("Weekly bookings scheduled. Running the scheduler...")
-        while True:
-            schedule.run_pending()
-            time.sleep(1)
+    # Schedule bookings in parallel
+    schedule_bookings_parallel(
+        bot,
+        config["classes"],
+        config["booking_execution"],
+        offset_seconds,
+        retry_attempts,
+        retry_delay_minutes,
+        time_zone,
+        max_threads,
+    )
+
+    logger.info("All bookings completed.")

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,17 +1,12 @@
-# tests/test_service.py
-
 import unittest
-from datetime import datetime, timedelta
+from datetime import datetime
 from unittest.mock import patch
 
 import pandas as pd
 import pytz
 
 from pysportbot.service.config_validator import validate_activities, validate_config
-
-# 1) Import each function from its exact module path:
 from pysportbot.service.scheduling import calculate_class_day, calculate_next_execution
-from pysportbot.service.service import run_service
 from pysportbot.utils.errors import ErrorMessages
 
 
@@ -24,7 +19,6 @@ class TestService(unittest.TestCase):
     # ------------------------------------------------------------------------
     # 1. Tests for config validation
     # ------------------------------------------------------------------------
-
     def test_validate_config_missing_required_key(self):
         """
         Test that validate_config raises an error if required keys are missing.
@@ -35,6 +29,7 @@ class TestService(unittest.TestCase):
             "password": "secret",
             "centre": "my-gim",
             "classes": [],
+            "booking_execution": "Monday 07:30:00",
         }
         with self.assertRaises(ValueError) as ctx:
             validate_config(config_missing_email)
@@ -47,7 +42,7 @@ class TestService(unittest.TestCase):
         """
         Test that validate_config raises an error if 'classes' are missing required keys.
         The actual message is from ErrorMessages.invalid_class_definition(),
-        e.g. "Each class must include 'activity', 'class_day', 'class_time', 'booking_execution', and 'weekly'."
+        e.g. "Each class must include 'activity', 'class_day', and 'class_time'."
         """
         config = {
             "email": "someone@example.com",
@@ -55,54 +50,23 @@ class TestService(unittest.TestCase):
             "centre": "my-gim",
             "classes": [
                 {
-                    # Missing "activity", "class_day", etc.
+                    # Missing "activity", "class_day", and "class_time"
                     "weekly": True
                 }
             ],
+            "booking_execution": "Monday 07:30:00",
         }
         with self.assertRaises(ValueError) as ctx:
             validate_config(config)
 
         expected_message = ErrorMessages.invalid_class_definition()
-        self.assertIn(
-            expected_message,
-            str(ctx.exception),
-        )
-
-    def test_validate_config_invalid_weekly_now(self):
-        """
-        Test that validate_config raises an error if weekly == True but booking_execution == 'now'.
-        The actual message is from ErrorMessages.invalid_weekly_now(),
-        e.g. "Invalid combination: cannot use weekly=True with booking_execution='now'."
-        """
-        config = {
-            "email": "someone@example.com",
-            "password": "secret",
-            "centre": "my-gim",
-            "classes": [
-                {
-                    "activity": "Yoga",
-                    "class_day": "Monday",
-                    "class_time": "18:00:00",
-                    "booking_execution": "now",
-                    "weekly": True,
-                }
-            ],
-        }
-        with self.assertRaises(ValueError) as ctx:
-            validate_config(config)
-
-        expected_message = ErrorMessages.invalid_weekly_now()
-        self.assertIn(
-            expected_message,
-            str(ctx.exception),
-        )
+        self.assertIn(expected_message, str(ctx.exception))
 
     # ------------------------------------------------------------------------
     # 2. Tests for validating activities against SportBot
     # ------------------------------------------------------------------------
 
-    @patch("pysportbot.service.config_validator.SportBot")  # Correct import path to where SportBot is used
+    @patch("pysportbot.service.config_validator.SportBot")
     def test_validate_activities_unknown_activity(self, mock_sportbot_class):
         """
         Test that if the config specifies an activity not present in SportBot activities,
@@ -110,10 +74,11 @@ class TestService(unittest.TestCase):
         The actual message is from ErrorMessages.activity_not_found(...),
         e.g. "No activity found with the name 'CrossFit'. Available activities are: Yoga."
         """
+        # Mock the SportBot instance and available activities
         mock_bot_instance = mock_sportbot_class.return_value
-        # Suppose available activities is only "Yoga", but config has "CrossFit"
         mock_bot_instance.activities.return_value = pd.DataFrame({"name_activity": ["Yoga"]})
 
+        # Define a configuration with an unknown activity
         config = {
             "email": "test@example.com",
             "password": "password",
@@ -123,8 +88,6 @@ class TestService(unittest.TestCase):
                     "activity": "CrossFit",
                     "class_day": "Monday",
                     "class_time": "18:00:00",
-                    "booking_execution": "now",
-                    "weekly": False,
                 }
             ],
         }
@@ -139,363 +102,31 @@ class TestService(unittest.TestCase):
     # 3. Tests for the utility functions that calculate execution dates
     # ------------------------------------------------------------------------
 
-    @patch("pysportbot.service.scheduling.datetime", wraps=datetime)  # Patch datetime where it's actually used
+    @patch("pysportbot.service.scheduling.datetime", wraps=datetime)
     def test_calculate_next_execution(self, mock_datetime):
         """
         If today is Wednesday 2024-01-10, then 'Friday 07:30:00' should be 2 days ahead (2024-01-12).
         """
         tz = pytz.timezone("Europe/Madrid")
-        mock_now = tz.localize(datetime(2024, 1, 10, 12, 0, 0))  # Wednesday
+        mock_now = tz.localize(datetime(2024, 1, 10, 12, 0, 0))
         mock_datetime.now.return_value = mock_now
 
-        # Call the function
         result = calculate_next_execution("Friday 07:30:00", time_zone="Europe/Madrid")
-
-        # Expected result
         expected = tz.localize(datetime(2024, 1, 12, 7, 30, 0))
-
-        # Assert
         self.assertEqual(result, expected)
 
-    @patch("pysportbot.service.scheduling.datetime")  # Correct import path
+    @patch("pysportbot.service.scheduling.datetime")
     def test_calculate_class_day(self, mock_datetime):
         """
         If today is Wednesday 2024-01-10, the next Monday is 2024-01-15 (5 days later).
         """
         tz = pytz.timezone("Europe/Madrid")
-        mock_now = tz.localize(datetime(2024, 1, 10, 12, 0, 0))  # Wednesday
+        mock_now = tz.localize(datetime(2024, 1, 10, 12, 0, 0))
         mock_datetime.now.return_value = mock_now
 
         result = calculate_class_day("Monday", time_zone="Europe/Madrid")
         expected = tz.localize(datetime(2024, 1, 15, 12, 0, 0))
         self.assertEqual(result.date(), expected.date())
-
-    # ------------------------------------------------------------------------
-    # 4. Tests for the main booking logic (weekly vs. one-off)
-    # ------------------------------------------------------------------------
-
-    @patch("pysportbot.service.scheduling.datetime", wraps=datetime)
-    @patch("pysportbot.service.service.SportBot")
-    @patch("pysportbot.service.service.schedule.run_pending")
-    @patch("pysportbot.service.service.time.sleep", return_value=None)
-    def test_weekly_scheduling(self, mock_sleep, mock_run_pending, mock_sportbot_class, mock_datetime):
-        """
-        Test that run_service schedules a weekly job and (theoretically) calls schedule.run_pending() in a loop.
-        """
-        tz = pytz.timezone("Europe/Madrid")
-        fixed_now = tz.localize(datetime(2024, 1, 3, 12, 0, 0))  # Wednesday
-        mock_datetime.now.return_value = fixed_now
-
-        mock_bot_instance = mock_sportbot_class.return_value
-        mock_bot_instance.activities.return_value = pd.DataFrame({"name_activity": ["Yoga"]})
-        mock_bot_instance.daily_slots.return_value = pd.DataFrame({"start_timestamp": ["2024-01-08 18:00:00"]})
-
-        config = {
-            "email": "test@example.com",
-            "password": "password",
-            "centre": "my-gim",
-            "classes": [
-                {
-                    "activity": "Yoga",
-                    "class_day": "Monday",
-                    "class_time": "18:00:00",
-                    "booking_execution": "Friday 07:30:00",
-                    "weekly": True,
-                }
-            ],
-        }
-
-        # Ensure schedule.jobs is patched to avoid infinite loops
-        with patch("pysportbot.service.service.schedule.jobs", new=[]):
-            run_service(
-                config,
-                offset_seconds=0,
-                retry_attempts=1,
-                retry_delay_minutes=0,
-                time_zone="Europe/Madrid",
-            )
-
-        mock_bot_instance.login.assert_called_with("test@example.com", "password", "my-gim")
-        self.assertTrue(mock_bot_instance.login.called, "Expected login to be called")
-
-    @patch("pysportbot.service.scheduling.datetime")
-    @patch("pysportbot.service.service.SportBot")
-    @patch("pysportbot.service.service.schedule.run_pending")
-    @patch("pysportbot.service.service.time.sleep", return_value=None)
-    def test_now_scheduling(self, mock_sleep, mock_run_pending, mock_sportbot_class, mock_datetime):
-        """
-        Test that a one-off booking with "now" triggers an immediate booking
-        (no infinite scheduling loop).
-        """
-        # Mock datetime.now() to a fixed date
-        tz = pytz.timezone("Europe/Madrid")
-        fixed_now = tz.localize(datetime(2024, 1, 7, 12, 0, 0))  # Sunday
-        mock_datetime.now.return_value = fixed_now
-        mock_datetime.strptime.side_effect = lambda s, fmt: datetime.strptime(s, fmt)
-
-        mock_bot_instance = mock_sportbot_class.return_value
-        mock_bot_instance.activities.return_value = pd.DataFrame({"name_activity": ["Yoga"]})
-        # Booking date should be 2024-01-08 (Monday)
-        mock_bot_instance.daily_slots.return_value = pd.DataFrame({"start_timestamp": ["2024-01-08 18:00:00"]})
-
-        run_service(
-            {
-                "email": "test@example.com",
-                "password": "password",
-                "centre": "my-gim",
-                "classes": [
-                    {
-                        "activity": "Yoga",
-                        "class_day": "Monday",
-                        "class_time": "18:00:00",
-                        "booking_execution": "now",
-                        "weekly": False,
-                    }
-                ],
-            },
-            offset_seconds=0,
-            retry_attempts=1,
-            retry_delay_minutes=0,
-            time_zone="Europe/Madrid",
-        )
-
-        # Check calls
-        mock_bot_instance.daily_slots.assert_called_once()
-        mock_bot_instance.book.assert_called_with(activity="Yoga", start_time="2024-01-08 18:00:00")
-
-        # "now" booking should not enter an infinite loop
-        mock_run_pending.assert_not_called()
-
-    # ------------------------------------------------------------------------
-    # 5. Tests for error handling (no matching slots, already booked, retries)
-    # ------------------------------------------------------------------------
-
-    @patch("pysportbot.service.booking.time.sleep", return_value=None)
-    @patch("pysportbot.service.service.schedule.run_pending")
-    @patch("pysportbot.service.service.SportBot")
-    def test_no_matching_slots_error(self, mock_sportbot_class, mock_run_pending, mock_sleep):
-        """
-        If daily_slots() returns no row matching class_time, we expect a ValueError.
-        However, run_service handles it internally and logs an error instead of raising.
-        Thus, we'll check the log messages.
-        """
-        mock_bot_instance = mock_sportbot_class.return_value
-        mock_bot_instance.activities.return_value = pd.DataFrame({"name_activity": ["Yoga"]})
-        mock_bot_instance.daily_slots.return_value = pd.DataFrame({"start_timestamp": []})
-
-        config = {
-            "email": "test@example.com",
-            "password": "password",
-            "centre": "my-gim",
-            "classes": [
-                {
-                    "activity": "Yoga",
-                    "class_day": "Monday",
-                    "class_time": "18:00:00",
-                    "booking_execution": "now",
-                    "weekly": False,
-                }
-            ],
-        }
-
-        # We need to mock datetime to return a fixed date for calculate_class_day
-        with patch("pysportbot.service.scheduling.datetime") as mock_datetime:
-            tz = pytz.timezone("Europe/Madrid")
-            fixed_now = tz.localize(datetime(2024, 1, 7, 12, 0, 0))  # Sunday
-            mock_datetime.now.return_value = fixed_now
-            mock_datetime.strptime.side_effect = lambda s, fmt: datetime.strptime(s, fmt)
-
-            with self.assertLogs("pysportbot.service", level="WARNING") as cm:
-                run_service(
-                    config,
-                    offset_seconds=0,
-                    retry_attempts=1,
-                    retry_delay_minutes=0,
-                    time_zone="Europe/Madrid",
-                )
-
-        # Expected log messages:
-        # WARNING  pysportbot.service: Attempt 1 failed for Yoga: ...
-        # ERROR    pysportbot.service: Failed to book Yoga after 1 attempts.
-
-        expected_warning = ErrorMessages.no_matching_slots_for_time("Yoga", "18:00:00", "2024-01-08")
-        self.assertIn(expected_warning, cm.output[0])
-
-        expected_error = "Failed to book Yoga after 1 attempts."
-        self.assertIn(expected_error, cm.output[1])
-
-    @patch("pysportbot.service.booking.time.sleep", return_value=None)
-    @patch("pysportbot.service.service.schedule.run_pending")
-    @patch("pysportbot.service.service.SportBot")
-    def test_slot_already_booked_error(self, mock_sportbot_class, mock_run_pending, mock_sleep):
-        """
-        If bot.book(...) raises a slot_already_booked error, the code should skip further retries.
-        """
-        mock_bot_instance = mock_sportbot_class.return_value
-        mock_bot_instance.activities.return_value = pd.DataFrame({"name_activity": ["Yoga"]})
-        mock_bot_instance.daily_slots.return_value = pd.DataFrame({"start_timestamp": ["2024-01-08 18:00:00"]})
-
-        # The "slot already booked" message
-        already_booked_msg = ErrorMessages.slot_already_booked()
-        mock_bot_instance.book.side_effect = ValueError(already_booked_msg)
-
-        config = {
-            "email": "test@example.com",
-            "password": "password",
-            "centre": "my-gim",
-            "classes": [
-                {
-                    "activity": "Yoga",
-                    "class_day": "Monday",
-                    "class_time": "18:00:00",
-                    "booking_execution": "now",
-                    "weekly": False,
-                }
-            ],
-        }
-
-        # Mock datetime to set the booking date to 2024-01-08
-        with patch("pysportbot.service.scheduling.datetime") as mock_datetime:
-            tz = pytz.timezone("Europe/Madrid")
-            fixed_now = tz.localize(datetime(2024, 1, 7, 12, 0, 0))  # Sunday
-            mock_datetime.now.return_value = fixed_now
-            mock_datetime.strptime.side_effect = lambda s, fmt: datetime.strptime(s, fmt)
-
-            with self.assertLogs("pysportbot.service", level="WARNING") as cm:
-                run_service(
-                    config, offset_seconds=0, retry_attempts=2, retry_delay_minutes=1, time_zone="Europe/Madrid"
-                )
-
-        expected_warning = already_booked_msg
-        self.assertIn(expected_warning, cm.output[0])
-
-        # Ensure that book was called only once
-        mock_bot_instance.book.assert_called_once()
-
-    @patch("pysportbot.service.booking.time.sleep", return_value=None)
-    @patch("pysportbot.service.service.schedule.run_pending")
-    @patch("pysportbot.service.service.SportBot")
-    def test_retry_mechanism(self, mock_sportbot_class, mock_run_pending, mock_sleep):
-        """
-        If booking fails for a reason other than 'already booked',
-        the service should retry up to 'retry_attempts'.
-        """
-        mock_bot_instance = mock_sportbot_class.return_value
-        mock_bot_instance.activities.return_value = pd.DataFrame({"name_activity": ["Yoga"]})
-        mock_bot_instance.daily_slots.return_value = pd.DataFrame({"start_timestamp": ["2024-01-08 18:00:00"]})
-
-        # Modify the side_effect to raise an error on every booking attempt
-        def side_effect(*args, **kwargs):
-            raise ValueError("Some random booking error")
-
-        mock_bot_instance.book.side_effect = side_effect
-
-        config = {
-            "email": "test@example.com",
-            "password": "password",
-            "centre": "my-gim",
-            "classes": [
-                {
-                    "activity": "Yoga",
-                    "class_day": "Monday",
-                    "class_time": "18:00:00",
-                    "booking_execution": "now",
-                    "weekly": False,
-                }
-            ],
-        }
-
-        # Mock datetime to set the booking date to 2024-01-08
-        with patch("pysportbot.service.scheduling.datetime") as mock_datetime:
-            tz = pytz.timezone("Europe/Madrid")
-            fixed_now = tz.localize(datetime(2024, 1, 7, 12, 0, 0))  # Sunday
-            mock_datetime.now.return_value = fixed_now
-            mock_datetime.strptime.side_effect = lambda s, fmt: datetime.strptime(s, fmt)
-
-            with self.assertLogs("pysportbot.service", level="WARNING") as cm:
-                run_service(
-                    config, offset_seconds=0, retry_attempts=2, retry_delay_minutes=1, time_zone="Europe/Madrid"
-                )
-
-        # Expected log messages:
-        # WARNING  pysportbot.service: Attempt 1 failed for Yoga: Some random booking error
-        # WARNING  pysportbot.service: Attempt 2 failed for Yoga: Some random booking error
-        # ERROR    pysportbot.service: Failed to book Yoga after 2 attempts.
-
-        expected_warning_1 = "Attempt 1 failed for Yoga: Some random booking error"
-        expected_warning_2 = "Attempt 2 failed for Yoga: Some random booking error"
-        expected_error = "Failed to book Yoga after 2 attempts."
-
-        # Ensure that all expected log messages are present
-        self.assertIn(expected_warning_1, cm.output[0])
-        self.assertIn(expected_warning_2, cm.output[1])
-        self.assertIn(expected_error, cm.output[2])
-
-        # We expect exactly two calls to book(): both fail
-        self.assertEqual(mock_bot_instance.book.call_count, 2)
-        self.assertTrue(mock_sleep.called, "Expected to sleep between retries")
-
-    @patch("pysportbot.service.scheduling.datetime", wraps=datetime)
-    def test_calculate_next_execution_time_already_passed(self, mock_datetime):
-        """
-        If today is Monday 2024-12-30 and the time is 07:00:00,
-        and the booking execution is 'Monday 06:30:00', the next execution
-        should be on Monday 2025-01-06.
-        """
-        tz = pytz.timezone("Europe/Madrid")
-        mock_now = tz.localize(datetime(2024, 12, 30, 7, 0, 0))
-        mock_datetime.now.return_value = mock_now
-
-        # Call the function
-        result = calculate_next_execution("Monday 06:30:00", time_zone="Europe/Madrid")
-
-        # Expected result
-        expected = tz.localize(datetime(2025, 1, 6, 6, 30, 0))
-        self.assertEqual(result, expected)
-
-    @patch("pysportbot.service.booking.time.sleep", return_value=None)
-    @patch("pysportbot.service.service.SportBot")
-    def test_slot_matching(self, mock_sportbot_class, mock_sleep):
-        """
-        Ensure the service correctly matches a slot with a specific time.
-        """
-        today = datetime.now()
-        days_until_tuesday = (1 - today.weekday()) % 7  # 1 = Tuesday
-        next_tuesday = today + timedelta(days=days_until_tuesday)
-        next_tuesday_str = next_tuesday.strftime("%Y-%m-%d 12:00:00")
-        next_tuesday_later_str = next_tuesday.strftime("%Y-%m-%d 15:00:00")
-
-        mock_bot_instance = mock_sportbot_class.return_value
-        mock_bot_instance.activities.return_value = pd.DataFrame({"name_activity": ["Gimnasio"]})
-        mock_bot_instance.daily_slots.return_value = pd.DataFrame(
-            {"start_timestamp": [next_tuesday_str, next_tuesday_later_str]}
-        )
-
-        config = {
-            "email": "test@example.com",
-            "password": "password",
-            "centre": "my-gim",
-            "classes": [
-                {
-                    "activity": "Gimnasio",
-                    "class_day": "Tuesday",
-                    "class_time": "12:00:00",
-                    "booking_execution": "Monday 06:30:00",
-                    "weekly": False,
-                }
-            ],
-        }
-
-        run_service(
-            config,
-            offset_seconds=0,
-            retry_attempts=1,
-            retry_delay_minutes=0,
-            time_zone="Europe/Madrid",
-        )
-
-        # Ensure the correct slot was booked
-        mock_bot_instance.book.assert_called_with(activity="Gimnasio", start_time=next_tuesday_str)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds initial support for running bookings with multiple threads in the service. By default, all available threads are used to make bookings in parallel. We also remove the activity-specific booking execution as I don't see a big use case for this and it just complicates the threading. More tests to the service to be added in the future.