### PR TITLE
Add py313 support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,8 @@
 {
 	"name": "pysportbot",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/python:1-3.12-bullseye",
+	// Full list of images: https://mcr.microsoft.com/v2/devcontainers/python/tags/list
+	"image": "mcr.microsoft.com/devcontainers/python:1-3.13-bullseye",
 	"features": {
 		"ghcr.io/devcontainers-contrib/features/poetry:2": {
 			"version": "2.0.0"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
       fail-fast: false
     steps:
       - name: Check out

--- a/poetry.lock
+++ b/poetry.lock
@@ -2514,5 +2514,5 @@ type = ["pytest-mypy"]
 
 [metadata]
 lock-version = "2.1"
-python-versions = ">=3.9,<3.13"
-content-hash = "6e9d05238fe5ad1c5d56556e84d6442abb571d33774f335ea0394cc2c8a790d7"
+python-versions = ">=3.9,<3.14"
+content-hash = "1fefca618a9337ba067f928662338703eaec44397039ad33bbfdf32ee1c3bc23"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,11 +11,10 @@ readme = "README.md"
 packages = [
   { include = "pysportbot" }
 ]
-requires-python = ">=3.9,<3.13"
-dynamic = ["dependencies"]
+dynamic = ["requires-python", "dependencies"]
 
 [tool.poetry.dependencies]
-python = ">=3.9,<3.13"
+python = ">=3.9,<3.14"
 requests = "^2.32.3"
 beautifulsoup4 = "^4.12.3"
 pandas = "^2.2.3"

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,13 @@
 [tox]
 skipsdist = true
-envlist = py310, py311, py312
+envlist = py310, py311, py312, py313
 
 [gh-actions]
 python =
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
 [testenv]
 passenv = PYTHON_VERSION,SPORTBOT_EMAIL,SPORTBOT_PASSWORD,SPORTBOT_CENTRE
 allowlist_externals = poetry


### PR DESCRIPTION
This PR adds initial [Python 3.13](https://docs.python.org/3/whatsnew/3.13.html) support. Also changes the devcontainer default accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for Python 3.13 across development container, GitHub Actions workflow, project configuration, and testing environments.

- **Chores**
	- Updated Python version compatibility and testing matrix to include the latest Python version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->