### PR TITLE
Re-authenticate before execution

### DIFF
--- a/pysportbot/service/booking.py
+++ b/pysportbot/service/booking.py
@@ -130,9 +130,9 @@ def schedule_bookings(
     logger.debug("Re-authenticating before booking.")
     try:
         bot.login(config["email"], config["password"], config["centre"])
-    except Exception as e:
-        logger.error(f"Re-authentication failed: {str(e)}")
-        raise ValueError("Failed to re-authenticate before booking execution") from e
+    except Exception:
+        logger.exception("Re-authentication failed before booking execution.")
+        raise
 
     # Submit bookings in parallel
     with ThreadPoolExecutor(max_workers=max_threads) as executor:

--- a/pysportbot/service/booking.py
+++ b/pysportbot/service/booking.py
@@ -128,7 +128,11 @@ def schedule_bookings(
 
     # Re-authenticate before booking
     logger.debug("Re-authenticating before booking.")
-    bot.login(config["email"], config["password"], config["centre"])
+    try:
+        bot.login(config["email"], config["password"], config["centre"])
+    except Exception as e:
+        logger.error(f"Re-authentication failed: {str(e)}")
+        raise ValueError("Failed to re-authenticate before booking execution") from e
 
     # Submit bookings in parallel
     with ThreadPoolExecutor(max_workers=max_threads) as executor:

--- a/pysportbot/service/service.py
+++ b/pysportbot/service/service.py
@@ -35,6 +35,8 @@ def run_service(
     validate_config(config)
 
     # Initialize the SportBot and authenticate
+    # Note: will re-authenticate before booking execution
+    # to ensure the session is still valid
     bot = SportBot(log_level=log_level, time_zone=time_zone)
     bot.login(config["email"], config["password"], config["centre"])
 
@@ -48,8 +50,7 @@ def run_service(
     # Schedule bookings in parallel
     schedule_bookings(
         bot,
-        config["classes"],
-        config["booking_execution"],
+        config,
         booking_delay,
         retry_attempts,
         retry_delay,

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -402,16 +402,22 @@ class TestBooking(unittest.TestCase):
 
         # 4. Everything else (bot, classes, etc.)
         mock_bot = MagicMock()
-        classes = [
-            {"activity": "Yoga", "class_day": "Monday", "class_time": "09:00:00"},
-            {"activity": "Boxing", "class_day": "Tuesday", "class_time": "10:00:00"},
-        ]
+
+        config = {
+            "email": "my@my.com",
+            "password": "pass",
+            "centre": "my-gim",
+            "booking_execution": "now",
+            "classes": [
+                {"activity": "Yoga", "class_day": "Monday", "class_time": "09:00:00"},
+                {"activity": "Boxing", "class_day": "Tuesday", "class_time": "10:00:00"},
+            ],
+        }
 
         # Call function under test
         schedule_bookings(
             bot=mock_bot,
-            classes=classes,
-            booking_execution="now",
+            config=config,
             booking_delay=2,
             retry_attempts=2,
             retry_delay=1,
@@ -425,7 +431,7 @@ class TestBooking(unittest.TestCase):
         mock_executor.assert_called_once_with(max_workers=2)
 
         # ThreadPoolExecutor.submit should have been called for each class:
-        self.assertEqual(mock_executor_instance.submit.call_count, len(classes))
+        self.assertEqual(mock_executor_instance.submit.call_count, len(config["classes"]))
         # as_completed was called with the dictionary of futures
         # but we only need to confirm it wasn't stuck
         self.assertTrue(mock_as_completed.called)


### PR DESCRIPTION
This PR makes sure that prior to booking execution, a re-authentication with the login service takes place. In case that the booking execution delay is very long, the session may expire.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a consolidated configuration dictionary for booking services
	- Enhanced authentication process before booking execution

- **Refactor**
	- Streamlined function signatures in booking and service modules
	- Simplified parameter passing by using a single configuration object

- **Tests**
	- Updated test cases to align with new configuration structure

The changes improve the overall organization and clarity of the booking process while maintaining existing core functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->