### PR TITLE
Re-authenticate prior to execution time

### DIFF
--- a/pysportbot/service/booking.py
+++ b/pysportbot/service/booking.py
@@ -101,7 +101,7 @@ def schedule_bookings(
     # Booking execution day and time
     booking_execution = config["booking_execution"]
 
-    # Exact time when booking will be executed (modulo global boooking delay)
+    # Exact time when booking will be executed (modulo global booking delay)
     execution_time = calculate_next_execution(booking_execution, time_zone)
 
     # Get the time now

--- a/pysportbot/service/booking.py
+++ b/pysportbot/service/booking.py
@@ -118,8 +118,12 @@ def schedule_bookings(
         )
         # Re-authenticate 60 seconds before booking execution
         reauth_time = time_until_execution - 60
-        # Wait for re-authentication
-        time.sleep(reauth_time)
+
+        if reauth_time <= 0:
+            logger.debug("Less than 60 seconds remain until execution; re-authenticating now.")
+        else:
+            logger.debug(f"Re-authenticating in {reauth_time:.2f} seconds.")
+            time.sleep(reauth_time)
 
         # Re-authenticate before booking
         logger.info("Re-authenticating before booking.")


### PR DESCRIPTION
This PR makes sure that the re-authentication in the service happens 60 seconds prior to the booking execution and guarantees that the booking execution happens at the exact specified time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced booking scheduling process with improved re-authentication mechanism.
	- Added more robust timing control for booking execution.

- **Refactor**
	- Removed separate waiting function and integrated execution timing logic directly into booking scheduling.
	- Simplified booking process workflow.

- **Tests**
	- Updated test suite to reflect changes in booking scheduling logic.
	- Removed specific waiting time test cases and added new tests for future execution handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->