### PR TITLE
Fix calculate_class_day in service

### DIFF
--- a/pysportbot/service/scheduling.py
+++ b/pysportbot/service/scheduling.py
@@ -56,6 +56,7 @@ def calculate_class_day(class_day: str, time_zone: str = "Europe/Madrid") -> dat
     now = datetime.now(tz)
     target_weekday = DAY_MAP[class_day.lower().strip()]
     days_ahead = target_weekday - now.weekday()
-    if days_ahead < 0:
+    # Ensure we always book for the upcoming week
+    if days_ahead <= 0:
         days_ahead += 7
     return now + timedelta(days=days_ahead)


### PR DESCRIPTION
Fixes a bug where bookings scheduled for e.g. NEXT Friday would be attempted on current day. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Refined the scheduling logic to ensure that if a class day coincides with today, bookings are automatically set for the following week, providing a more predictable scheduling experience.

- **Tests**
  - Introduced new tests to validate the scheduling behavior under various scenarios, ensuring consistent handling of same-day and midweek booking requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->