### PR TITLE
Make re-auth more robust

### DIFF
--- a/pysportbot/authenticator.py
+++ b/pysportbot/authenticator.py
@@ -30,6 +30,25 @@ class Authenticator:
         self.user_id = None
         # Centre selected by the user
         self.centre = centre
+        # Timeout of requests
+        self.timeout = (5, 10)
+
+    def is_session_valid(self) -> bool:
+        """
+        Check if the current session is still valid.
+
+        Returns:
+            bool: True if session is valid, False otherwise.
+        """
+        try:
+            response = self.session.post(Endpoints.USER, headers=self.headers, timeout=self.timeout)
+            if response.status_code == 200:
+                response_dict = json.loads(response.content.decode("utf-8"))
+                return response_dict.get("user", False) is not False
+            else:
+                return False
+        except Exception:
+            return False
 
     def login(self, email: str, password: str) -> None:
         """
@@ -46,11 +65,12 @@ class Authenticator:
 
         # Step 1: Fetch CSRF token
         logger.debug(f"GET {Endpoints.USER_LOGIN} | Headers: {json.dumps(self.headers, indent=2)}")
-        response = self.session.get(Endpoints.USER_LOGIN, headers=self.headers)
+        response = self.session.get(Endpoints.USER_LOGIN, headers=self.headers, timeout=self.timeout)
         if response.status_code != 200:
             logger.error(f"Failed to fetch login popup: {response.status_code}")
             raise RuntimeError(ErrorMessages.failed_fetch("login popup"))
         logger.debug("Login popup fetched successfully.")
+
         soup = BeautifulSoup(response.text, "html.parser")
         csrf_tag = soup.find("input", {"name": "_csrf_token"})
         if csrf_tag is None:
@@ -70,7 +90,7 @@ class Authenticator:
             f"POST {Endpoints.LOGIN_CHECK} | Headers: {json.dumps(self.headers, indent=2)} | "
             f"Payload: {json.dumps(payload, indent=2)}"
         )
-        response = self.session.post(Endpoints.LOGIN_CHECK, data=payload, headers=self.headers)
+        response = self.session.post(Endpoints.LOGIN_CHECK, data=payload, headers=self.headers, timeout=self.timeout)
         if response.status_code != 200:
             logger.error(f"Login failed: {response.status_code}, {response.text}")
             raise ValueError(ErrorMessages.failed_login())
@@ -79,7 +99,7 @@ class Authenticator:
         # Step 3: Retrieve credentials for Nubapp
         cred_endpoint = Endpoints.get_cred_endpoint(self.centre)
         logger.debug(f"GET {cred_endpoint} | Headers: {json.dumps(self.headers, indent=2)}")
-        response = self.session.get(cred_endpoint, headers=self.headers)
+        response = self.session.get(cred_endpoint, headers=self.headers, timeout=self.timeout)
         if response.status_code != 200:
             logger.error(f"Failed to retrieve Nubapp credentials: {response.status_code}")
             raise RuntimeError(ErrorMessages.failed_fetch("credentials"))
@@ -94,14 +114,16 @@ class Authenticator:
             f"GET {Endpoints.NUBAP_LOGIN} | Headers: {json.dumps(self.headers, indent=2)} | "
             f"Params: {json.dumps(nubapp_creds, indent=2)}"
         )
-        response = self.session.get(Endpoints.NUBAP_LOGIN, headers=self.headers, params=nubapp_creds)
+        response = self.session.get(
+            Endpoints.NUBAP_LOGIN, headers=self.headers, params=nubapp_creds, timeout=self.timeout
+        )
         if response.status_code != 200:
             logger.error(f"Login to Nubapp failed: {response.status_code}, {response.text}")
             raise ValueError(ErrorMessages.failed_login_nubapp())
         logger.info("Login to Nubapp successful!")
 
         # Step 5: Get user information
-        response = self.session.post(Endpoints.USER, headers=self.headers, allow_redirects=True)
+        response = self.session.post(Endpoints.USER, headers=self.headers, allow_redirects=True, timeout=self.timeout)
 
         if response.status_code == 200:
             response_dict = json.loads(response.content.decode("utf-8"))

--- a/pysportbot/authenticator.py
+++ b/pysportbot/authenticator.py
@@ -44,10 +44,12 @@ class Authenticator:
             response = self.session.post(Endpoints.USER, headers=self.headers, timeout=self.timeout)
             if response.status_code == 200:
                 response_dict = json.loads(response.content.decode("utf-8"))
-                return response_dict.get("user", False) is not False
+                return bool(response_dict.get("user"))
             else:
+                logger.debug(f"Session validation failed with status code: {response.status_code}")
                 return False
-        except Exception:
+        except Exception as e:
+            logger.debug(f"Session validation failed with exception: {e}")
             return False
 
     def login(self, email: str, password: str) -> None:

--- a/pysportbot/service/booking.py
+++ b/pysportbot/service/booking.py
@@ -120,10 +120,10 @@ def schedule_bookings(
         # Re-authenticate before booking if necessary
         try:
             if bot._auth and bot._auth.is_session_valid():
+                logger.info("Session still valid. Skipping re-authentication.")
+            else:
                 logger.info("Attempting re-authenticating before booking.")
                 bot.login(config["email"], config["password"], config["centre"])
-            else:
-                logger.info("Session still valid. Skipping re-authentication.")
 
         except Exception as e:
             logger.warning(f"Re-authentication failed before booking execution with {e}.")
@@ -133,7 +133,7 @@ def schedule_bookings(
         remaining_time = (execution_time - now).total_seconds()
         if remaining_time > 0:
             logger.info(f"Waiting {remaining_time:.2f} seconds until booking execution.")
-            time.sleep(remaining_time)
+        time.sleep(max(0, remaining_time))
 
     # Global booking delay
     if booking_delay > 0:

--- a/pysportbot/service/booking.py
+++ b/pysportbot/service/booking.py
@@ -123,7 +123,7 @@ def schedule_bookings(
                 logger.info("Attempting re-authenticating before booking.")
                 bot.login(config["email"], config["password"], config["centre"])
             else:
-                logger.info("Session still valid. Skipping re-authentification.")
+                logger.info("Session still valid. Skipping re-authentication.")
 
         except Exception as e:
             logger.warning(f"Re-authentication failed before booking execution with {e}.")

--- a/pysportbot/service/booking.py
+++ b/pysportbot/service/booking.py
@@ -117,12 +117,17 @@ def schedule_bookings(
             logger.debug(f"Re-authenticating in {reauth_time:.2f} seconds.")
             time.sleep(reauth_time)
 
-        # Re-authenticate before booking
-        logger.info("Re-authenticating before booking.")
+        # Re-authenticate before booking if necessary
         try:
-            bot.login(config["email"], config["password"], config["centre"])
-        except Exception:
-            logger.warning("Re-authentication failed before booking execution.")
+            session_valid = bot._auth.is_session_valid()
+            if not session_valid:
+                logger.info("Attempting re-authenticating before booking.")
+                bot.login(config["email"], config["password"], config["centre"])
+            else:
+                logger.info("Session still valid. Skipping re-authentification.")
+
+        except Exception as e:
+            logger.warning(f"Re-authentication failed before booking execution with {e}.")
 
         # Wait the remaining time until execution
         now = datetime.now(pytz.timezone(time_zone))

--- a/pysportbot/service/booking.py
+++ b/pysportbot/service/booking.py
@@ -119,8 +119,7 @@ def schedule_bookings(
 
         # Re-authenticate before booking if necessary
         try:
-            session_valid = bot._auth.is_session_valid()
-            if not session_valid:
+            if bot._auth and bot._auth.is_session_valid():
                 logger.info("Attempting re-authenticating before booking.")
                 bot.login(config["email"], config["password"], config["centre"])
             else:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -302,7 +302,12 @@ class TestBooking(unittest.TestCase):
         tz = pytz.timezone("Europe/Madrid")
         mock_now = tz.localize(datetime(2024, 1, 8, 9, 0, 0))  # Current time
         mock_execution_time = tz.localize(datetime(2024, 1, 8, 10, 0, 0))  # 1 hour later
-        mock_datetime.now.return_value = mock_now
+
+        # Mock datetime.now() to return different values for each call
+        mock_datetime.now.side_effect = [
+            mock_now,  # First call - initial time check
+            mock_execution_time,  # Second call - after session validation, time has "advanced"
+        ]
 
         # Mock the calculate_next_execution function to return the future execution time
         with patch("pysportbot.service.booking.calculate_next_execution", return_value=mock_execution_time):
@@ -333,7 +338,7 @@ class TestBooking(unittest.TestCase):
         # Assert the correct sleep calls
         time_until_execution = (mock_execution_time - mock_now).total_seconds()
         reauth_sleep = time_until_execution - 60  # Time until reauthentication
-        remaining_time = 0  # Should be 0 since datetime.now is mocked to not advance
+        remaining_time = 0  # Should be 0 since second datetime.now returns execution_time
 
         # Expected sleep calls in the correct order
         expected_sleep_calls = [
@@ -360,7 +365,12 @@ class TestBooking(unittest.TestCase):
         tz = pytz.timezone("Europe/Madrid")
         mock_now = tz.localize(datetime(2024, 1, 8, 9, 0, 0))  # Current time
         mock_execution_time = tz.localize(datetime(2024, 1, 8, 10, 0, 0))  # 1 hour later
-        mock_datetime.now.return_value = mock_now
+
+        # Mock datetime.now() to return different values for each call
+        mock_datetime.now.side_effect = [
+            mock_now,  # First call - initial time check
+            mock_execution_time,  # Second call - after session validation, time has "advanced"
+        ]
 
         # Mock the calculate_next_execution function to return the future execution time
         with patch("pysportbot.service.booking.calculate_next_execution", return_value=mock_execution_time):
@@ -391,7 +401,7 @@ class TestBooking(unittest.TestCase):
         # Assert the correct sleep calls
         time_until_execution = (mock_execution_time - mock_now).total_seconds()
         reauth_sleep = time_until_execution - 60  # Time until session check
-        remaining_time = 0  # Should be 0 since datetime.now is mocked to not advance
+        remaining_time = 0  # Should be 0 since second datetime.now returns execution_time
 
         # Expected sleep calls in the correct order
         expected_sleep_calls = [
@@ -418,7 +428,12 @@ class TestBooking(unittest.TestCase):
         tz = pytz.timezone("Europe/Madrid")
         mock_now = tz.localize(datetime(2024, 1, 8, 9, 0, 0))  # Current time
         mock_execution_time = tz.localize(datetime(2024, 1, 8, 10, 0, 0))  # 1 hour later
-        mock_datetime.now.return_value = mock_now
+
+        # Mock datetime.now() to return different values for each call
+        mock_datetime.now.side_effect = [
+            mock_now,  # First call - initial time check
+            mock_execution_time,  # Second call - after exception, time has "advanced"
+        ]
 
         # Mock the calculate_next_execution function to return the future execution time
         with patch("pysportbot.service.booking.calculate_next_execution", return_value=mock_execution_time):
@@ -449,7 +464,7 @@ class TestBooking(unittest.TestCase):
         # Assert the correct sleep calls
         time_until_execution = (mock_execution_time - mock_now).total_seconds()
         reauth_sleep = time_until_execution - 60
-        remaining_time = 0
+        remaining_time = 0  # Should be 0 since second datetime.now returns execution_time
 
         # Expected sleep calls in the correct order
         expected_sleep_calls = [


### PR DESCRIPTION
Recently observed some re-authentification issues from Nubapp servers which resulted in hanging requests. Re-authentification is now only performed if session is not valid anymore. Also added timeout to requests so that booking may proceed even if re-authentification fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved session management with automatic validation of session status before re-authentication attempts.
- **Bug Fixes**
  - Enhanced error handling during session validation and re-authentication processes.
  - Adjusted booking timing to prevent negative sleep durations.
- **Tests**
  - Expanded test coverage to verify behavior for valid, invalid, and exception scenarios in session validation.
  - Renamed and added tests for clearer verification of session handling logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->